### PR TITLE
ci: upgrade download/upload artifact steps to v4

### DIFF
--- a/.github/workflows/terraform_plan.yaml
+++ b/.github/workflows/terraform_plan.yaml
@@ -29,7 +29,7 @@ jobs:
   plan:
     needs: [check_if_terraform_changed, get_packages]
     if: ${{ needs.check_if_terraform_changed.outputs.changed == 'true' }}
-    uses: vent-io/vent-io/.github/workflows/precheck_terraform_plan.yaml@main
+    uses: vent-io/vent-io/.github/workflows/precheck_terraform_plan_migration.yaml@main
     with:
       packages_json: ${{ needs.get_packages.outputs.packages }}
       working_dir: infrastructure
@@ -49,9 +49,9 @@ jobs:
     needs: [plan, check_if_terraform_changed]
     if: ${{ needs.check_if_terraform_changed.outputs.changed == 'true' }}
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: summary.md
+          name: summary.md-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Read file
         id: read_file


### PR DESCRIPTION
Upgrading the download/upload artifact steps to v4, because v3 is going to be deprecated at Nov 30th